### PR TITLE
Feat : Component Scan #18

### DIFF
--- a/src/main/java/spring01/core/AutoAppConfig.java
+++ b/src/main/java/spring01/core/AutoAppConfig.java
@@ -1,0 +1,20 @@
+package spring01.core;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import spring01.core.member.MemberRepository;
+import spring01.core.member.MemoryMemberRepository;
+
+@Configuration
+@ComponentScan (
+        basePackages =  "spring01.core",
+        basePackageClasses = AutoAppConfig.class,
+        excludeFilters =  @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Configuration.class)
+)
+// @ComponentScan : @Component 붙은 클래스를 찾아서 자동으로 스프링 빈으로 등록해 준다.
+// AppConfig, TestConfig를 일단 유지하기 위해 예외 필터로 Configuration.class 제거해준다. (일반적으로 제외하지 않음)
+public class AutoAppConfig {
+
+}

--- a/src/main/java/spring01/core/discount/RateDiscountPolicy.java
+++ b/src/main/java/spring01/core/discount/RateDiscountPolicy.java
@@ -1,8 +1,10 @@
 package spring01.core.discount;
 
+import org.springframework.stereotype.Component;
 import spring01.core.member.Grade;
 import spring01.core.member.Member;
 
+@Component
 public class RateDiscountPolicy implements DiscountPolicy {
 
     private int discountPercent = 10;

--- a/src/main/java/spring01/core/member/MemberServiceImpl.java
+++ b/src/main/java/spring01/core/member/MemberServiceImpl.java
@@ -1,9 +1,15 @@
 package spring01.core.member;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
 public class MemberServiceImpl implements MemberService{
 
     private final MemberRepository memberRepository;
 
+    // 생성자에 Autowired 붙여주면 MemberRepository 티입에 맞는 의존관계를 자동으로 연결해서 주입해 줌.
+    @Autowired
     public MemberServiceImpl(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }

--- a/src/main/java/spring01/core/member/MemoryMemberRepository.java
+++ b/src/main/java/spring01/core/member/MemoryMemberRepository.java
@@ -1,8 +1,11 @@
 package spring01.core.member;
 
+import org.springframework.stereotype.Component;
+
 import java.util.HashMap;
 import java.util.Map;
 
+@Component
 public class MemoryMemberRepository implements MemberRepository{
 
     private static Map<Long, Member> store = new HashMap<>();

--- a/src/main/java/spring01/core/order/OrderServiceImpl.java
+++ b/src/main/java/spring01/core/order/OrderServiceImpl.java
@@ -1,14 +1,18 @@
 package spring01.core.order;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import spring01.core.discount.DiscountPolicy;
 import spring01.core.member.Member;
 import spring01.core.member.MemberRepository;
 
+@Component
 public class OrderServiceImpl implements OrderService {
 
     private final MemberRepository memberRepository;
     private final DiscountPolicy discountPolicy;
 
+    @Autowired
     public OrderServiceImpl(MemberRepository memberRepository, DiscountPolicy discountPolicy) {
         this.memberRepository = memberRepository;
         this.discountPolicy = discountPolicy;

--- a/src/test/java/spring01/core/scan/AutoAppConfigTest.java
+++ b/src/test/java/spring01/core/scan/AutoAppConfigTest.java
@@ -1,0 +1,21 @@
+package spring01.core.scan;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import spring01.core.AutoAppConfig;
+import spring01.core.member.MemberService;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class AutoAppConfigTest {
+    
+    @Test
+    void basicScan() {
+        AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AutoAppConfig.class);
+
+        MemberService memberService = ac.getBean(MemberService.class);
+        assertThat(memberService).isInstanceOf(MemberService.class);
+
+    }
+}

--- a/src/test/java/spring01/core/scan/filter/BeanA.java
+++ b/src/test/java/spring01/core/scan/filter/BeanA.java
@@ -1,0 +1,5 @@
+package spring01.core.scan.filter;
+
+@MyIncludeComponent
+public class BeanA {
+}

--- a/src/test/java/spring01/core/scan/filter/BeanB.java
+++ b/src/test/java/spring01/core/scan/filter/BeanB.java
@@ -1,0 +1,5 @@
+package spring01.core.scan.filter;
+
+@MyExcludeComponent
+public class BeanB {
+}

--- a/src/test/java/spring01/core/scan/filter/ComponentFilterAppConfigTest.java
+++ b/src/test/java/spring01/core/scan/filter/ComponentFilterAppConfigTest.java
@@ -1,0 +1,38 @@
+package spring01.core.scan.filter;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.stereotype.Component;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.context.annotation.ComponentScan.*;
+
+public class ComponentFilterAppConfigTest {
+
+    @Test
+    void filterScan() {
+        ApplicationContext ac = new AnnotationConfigApplicationContext(ComponentFilterAppConfig.class);
+        BeanA beanA = ac.getBean("beanA", BeanA.class);
+        assertThat(beanA).isNotNull();
+
+        assertThrows(
+                NoSuchBeanDefinitionException.class,
+                () -> ac.getBean("beanB", BeanB.class));
+    }
+
+    @Configuration
+    @ComponentScan(
+            includeFilters = @Filter(type = FilterType.ANNOTATION, classes = MyIncludeComponent.class),
+            excludeFilters = @Filter(type = FilterType.ANNOTATION, classes = MyExcludeComponent.class)
+    )
+    static class ComponentFilterAppConfig {
+
+    }
+}

--- a/src/test/java/spring01/core/scan/filter/MyExcludeComponent.java
+++ b/src/test/java/spring01/core/scan/filter/MyExcludeComponent.java
@@ -1,0 +1,9 @@
+package spring01.core.scan.filter;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyExcludeComponent {
+}

--- a/src/test/java/spring01/core/scan/filter/MyIncludeComponent.java
+++ b/src/test/java/spring01/core/scan/filter/MyIncludeComponent.java
@@ -1,0 +1,11 @@
+package spring01.core.scan.filter;
+
+import org.springframework.stereotype.Indexed;
+
+import java.lang.annotation.*;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface MyIncludeComponent {
+}


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링

### 반영 브랜치
feat/13/component-scan-> main

### 변경 사항
- Component Scan 사용하여 의존관계 자동 주입
- 기존의 AppConfig, TestConfig 유지하기 위해서 excludeFilters로 @Configuration.class 제외
- 탐색할 패키지의 시작 위치 지정
- Filters -> 컴포넌트 스캔 대상, 제외 대상을 추가로 지정
- 컴포넌트 스캔에서의 빈 이름 중복과 오류 해결

### 테스트 결과
junit 테스트 결과 이상 없습니다.