### PR TITLE
Feat : Bean 생명주기 콜백 #26

### DIFF
--- a/src/test/java/spring01/core/lifecycle/BeanLifeCycleTest.java
+++ b/src/test/java/spring01/core/lifecycle/BeanLifeCycleTest.java
@@ -1,0 +1,31 @@
+package spring01.core.lifecycle;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+public class BeanLifeCycleTest {
+
+    @Test
+    public void lifeCycleTest() {
+        // ConfigurableApplicationContext은 close 하기 위해 쓰임 (AnnotationConfigApplicationContext의 상위 클래스)
+        ConfigurableApplicationContext ac = new AnnotationConfigApplicationContext(LifeCycleConfig.class);
+        NetworkClient client = ac.getBean(NetworkClient.class);
+        ac.close();
+    }
+
+    @Configuration
+    static class LifeCycleConfig {
+        @Bean
+        public NetworkClient networkClient() {
+            NetworkClient networkClient = new NetworkClient();
+            networkClient.setUrl("http://spring01-core.dev");
+            return networkClient;
+        }
+
+    }
+}

--- a/src/test/java/spring01/core/lifecycle/NetworkClient.java
+++ b/src/test/java/spring01/core/lifecycle/NetworkClient.java
@@ -1,0 +1,46 @@
+package spring01.core.lifecycle;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+
+public class NetworkClient implements InitializingBean, DisposableBean {
+
+    private String url;
+    public NetworkClient() {
+        System.out.println("생성자 호출, url = " + url);
+        connect();
+        call("초기화 연결 메세지");
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    // 서비스 시작 시 호출
+    public void connect() {
+        System.out.println("connect : " + url);
+    }
+
+    public void call(String message) {
+        System.out.println("call : " + url + "message = " + message);
+    }
+
+    // 서비스 종료 시 호출
+    public void disconnect() {
+        System.out.println("close : " + url);
+    }
+
+    // properties 세팅이 끝나면 (의존관계 주입이 끝나면) 호출해 준다.
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        System.out.println("NetworkClient.afterProperties");
+        connect();
+        call("초기화 연결 메세지");
+    }
+
+    @Override
+    public void destroy() throws Exception {
+        System.out.println("NetworkClient.destroy");
+        disconnect();
+    }
+}


### PR DESCRIPTION
### 반영 브랜치
feat/26/bean-lifecycle1

### 변경 사항
- 인터페이스(InitializingBean, DisposableBean)를 사용한 빈 생명주기 콜백
- 스프링 전용 인터페이스에 의존한다는 점, 초기화, 소멸 메서드의 이름을 변경할 수 없다는 점 등의 단점 때문에 현재는 잘 사용하지 않는다.

### 테스트 결과
junit 테스트 결과 이상 없음